### PR TITLE
Refactor(rpc) add messages variable in case try fails

### DIFF
--- a/gcloud_aio_pubsub_rpc/rpc.py
+++ b/gcloud_aio_pubsub_rpc/rpc.py
@@ -90,6 +90,7 @@ class PubSubRPCBase(ABC):
                 start = asyncio.get_running_loop().time()
                 num_tasks = len(self._consume_tasks)
                 max_messages = CONSUMER_MAX_MESSAGE_REQUEST - num_tasks
+                messages: list[Any] = []
                 if max_messages > 0:
                     try:
                         messages = await self.subscriber.pull(


### PR DESCRIPTION
When having a problem with the connection apart from logging the error `ERROR:gcloud_aio_pubsub_rpc.rpc:Network error, failed to pull messages` it then fails because is trying to access the `messages` variable which hasn't been created due to the error.

`UnboundLocalError: cannot access local variable 'messages' where it is not associated with a value`